### PR TITLE
feat: add mobile responsive top app bar

### DIFF
--- a/src/components/workbench/editor-overview-tab.tsx
+++ b/src/components/workbench/editor-overview-tab.tsx
@@ -51,7 +51,11 @@ export interface DashboardCommandState {
     relation?: RelationState;
 }
 
-export function EditorOverviewTab() {
+interface EditorOverviewTabProps {
+    onEntityOpen?: () => void;
+}
+
+export function EditorOverviewTab(props: EditorOverviewTabProps = {}) {
 
     const [storageInfo, setStorageInfo] = useState<StateStorageInfo>(DefaultStateStorageInfo());
     const [renameState, setRenameState] = useState<RenameState>({isOpen: false});
@@ -126,6 +130,7 @@ export function EditorOverviewTab() {
             // assert that node.type is an entity type
             if (IsEntityType(node.type)) {
                 showEntityFromId(node.type, node.id, path);
+                props.onEntityOpen?.();
             } else {
                 throw new Error(`Unknown node type: ${node.type}`);
             }


### PR DESCRIPTION
## Summary
- switch layout to a top app bar with burger menu on small screens
- allow mobile users to navigate relations, chat, and connections fullscreen
- add workspace view so dashboards and relations remain accessible on mobile

## Testing
- `pnpm lint` (fails: How would you like to configure ESLint?)
- `pnpm tsc`


------
https://chatgpt.com/codex/tasks/task_e_68ac27ced09483268881c49b6e6cafab