### PR TITLE
feat: modernize dark mode theme with softer colors

### DIFF
--- a/src/components/workflow/flow-theme.css
+++ b/src/components/workflow/flow-theme.css
@@ -24,12 +24,16 @@
 }
 
 .react-flow.dark {
-    --xy-background-color: #0a0a0a;
+    --xy-background-color: #12151a;
     --xy-node-boxshadow-default:
-            0px 3.54px 4.55px 0px rgba(255, 255, 255, 0.05),
-                /* light shadow */ 0px 3.54px 4.55px 0px rgba(255, 255, 255, 0.13),
-                /* medium shadow */ 0px 0.51px 1.01px 0px rgba(255, 255, 255, 0.2); /* smallest shadow */
-    --xy-theme-color-focus: #535353;
+            0px 3.54px 4.55px 0px rgba(0, 0, 0, 0.2),
+                /* light shadow */ 0px 3.54px 4.55px 0px rgba(0, 0, 0, 0.15),
+                /* medium shadow */ 0px 0.51px 1.01px 0px rgba(0, 0, 0, 0.1); /* smallest shadow */
+    --xy-theme-color-focus: #2a2f38;
+    --xy-node-border-default: 1px solid #2a2f38;
+    --xy-handle-background-color-default: #1e2128;
+    --xy-handle-border-color-default: #4a5568;
+    --xy-edge-label-color-default: #a0aec0;
 }
 
 /* Customizing Default Theming */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -67,34 +67,34 @@ body {
     --node-glow: 0 0 0 1px hsl(var(--primary) / 0.1), 0 10px 25px -5px hsl(var(--primary) / 0.25);
   }
   .dark {
-    --muted-background: 240 5% 4%;
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-light: 240 4.9% 10.2%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
+    --muted-background: 220 13% 8%;
+    --background: 222 14% 7%;
+    --foreground: 210 20% 98%;
+    --card: 220 13% 10%;
+    --card-foreground: 210 20% 98%;
+    --popover: 220 13% 10%;
+    --popover-foreground: 210 20% 98%;
+    --primary: 210 20% 98%;
+    --primary-foreground: 220 13% 10%;
+    --secondary: 215 14% 16%;
+    --secondary-foreground: 210 20% 98%;
+    --muted: 215 14% 16%;
+    --muted-light: 218 14% 12%;
+    --muted-foreground: 215 16% 57%;
+    --accent: 215 14% 16%;
+    --accent-foreground: 210 20% 98%;
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --destructive-foreground: 210 20% 98%;
+    --border: 215 14% 18%;
+    --input: 215 14% 18%;
+    --ring: 215 20% 65%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
-    --node-shadow: 0 10px 25px -5px hsl(217 91% 60% / 0.25), 0 4px 6px -2px hsl(217 91% 60% / 0.1);
-    --node-glow: 0 0 0 1px hsl(var(--primary) / 0.2), 0 10px 25px -5px hsl(var(--primary) / 0.4);
+    --node-shadow: 0 4px 12px -2px hsl(0 0% 0% / 0.3), 0 2px 4px -1px hsl(0 0% 0% / 0.15);
+    --node-glow: 0 0 0 1px hsl(var(--primary) / 0.1), 0 4px 12px -2px hsl(var(--primary) / 0.15);
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace near-black backgrounds with rich dark blue-grays (7% lightness with 220-222° hue)
- Add subtle blue undertone for a modern, sophisticated feel
- Reduce node shadow/glow intensity for a more refined appearance
- Update React Flow canvas theme to match new dark mode palette

The new dark theme provides better readability and eye comfort while maintaining strong contrast and visual hierarchy.