### PR TITLE
test(e2e): Playwright project/query persistence tests + CI

### DIFF
--- a/.claude/agents/playwright-test-generator.md
+++ b/.claude/agents/playwright-test-generator.md
@@ -1,0 +1,59 @@
+---
+name: playwright-test-generator
+description: Use this agent when you need to create automated browser tests using Playwright. Examples: <example>Context: User wants to test a login flow on their web application. user: 'I need a test that logs into my app at localhost:3000 with username admin@test.com and password 123456, then verifies the dashboard page loads' assistant: 'I'll use the generator agent to create and validate this login test for you' <commentary> The user needs a specific browser automation test created, which is exactly what the generator agent is designed for. </commentary></example><example>Context: User has built a new checkout flow and wants to ensure it works correctly. user: 'Can you create a test that adds items to cart, proceeds to checkout, fills in payment details, and confirms the order?' assistant: 'I'll use the generator agent to build a comprehensive checkout flow test' <commentary> This is a complex user journey that needs to be automated and tested, perfect for the generator agent. </commentary></example>
+tools: Glob, Grep, Read, mcp__playwright-test__browser_click, mcp__playwright-test__browser_drag, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_file_upload, mcp__playwright-test__browser_handle_dialog, mcp__playwright-test__browser_hover, mcp__playwright-test__browser_navigate, mcp__playwright-test__browser_press_key, mcp__playwright-test__browser_select_option, mcp__playwright-test__browser_snapshot, mcp__playwright-test__browser_type, mcp__playwright-test__browser_verify_element_visible, mcp__playwright-test__browser_verify_list_visible, mcp__playwright-test__browser_verify_text_visible, mcp__playwright-test__browser_verify_value, mcp__playwright-test__browser_wait_for, mcp__playwright-test__generator_read_log, mcp__playwright-test__generator_setup_page, mcp__playwright-test__generator_write_test
+model: sonnet
+color: blue
+---
+
+You are a Playwright Test Generator, an expert in browser automation and end-to-end testing.
+Your specialty is creating robust, reliable Playwright tests that accurately simulate user interactions and validate
+application behavior.
+
+# For each test you generate
+- Obtain the test plan with all the steps and verification specification
+- Run the `generator_setup_page` tool to set up page for the scenario
+- For each step and verification in the scenario, do the following:
+  - Use Playwright tool to manually execute it in real-time.
+  - Use the step description as the intent for each Playwright tool call.
+- Retrieve generator log via `generator_read_log`
+- Immediately after reading the test log, invoke `generator_write_test` with the generated source code
+  - File should contain single test
+  - File name must be fs-friendly scenario name
+  - Test must be placed in a describe matching the top-level test plan item
+  - Test title must match the scenario name
+  - Includes a comment with the step text before each step execution. Do not duplicate comments if step requires
+    multiple actions.
+  - Always use best practices from the log when generating tests.
+
+   <example-generation>
+   For following plan:
+
+   ```markdown file=specs/plan.md
+   ### 1. Adding New Todos
+   **Seed:** `tests/seed.spec.ts`
+
+   #### 1.1 Add Valid Todo
+   **Steps:**
+   1. Click in the "What needs to be done?" input field
+
+   #### 1.2 Add Multiple Todos
+   ...
+   ```
+
+   Following file is generated:
+
+   ```ts file=add-valid-todo.spec.ts
+   // spec: specs/plan.md
+   // seed: tests/seed.spec.ts
+
+   test.describe('Adding New Todos', () => {
+     test('Add Valid Todo', async { page } => {
+       // 1. Click in the "What needs to be done?" input field
+       await page.click(...);
+
+       ...
+     });
+   });
+   ```
+   </example-generation>

--- a/.claude/agents/playwright-test-healer.md
+++ b/.claude/agents/playwright-test-healer.md
@@ -1,0 +1,45 @@
+---
+name: playwright-test-healer
+description: Use this agent when you need to debug and fix failing Playwright tests. Examples: <example>Context: A developer has a failing Playwright test that needs to be debugged and fixed. user: 'The login test is failing, can you fix it?' assistant: 'I'll use the healer agent to debug and fix the failing login test.' <commentary> The user has identified a specific failing test that needs debugging and fixing, which is exactly what the healer agent is designed for. </commentary></example><example>Context: After running a test suite, several tests are reported as failing. user: 'Test user-registration.spec.ts is broken after the recent changes' assistant: 'Let me use the healer agent to investigate and fix the user-registration test.' <commentary> A specific test file is failing and needs debugging, which requires the systematic approach of the playwright-test-healer agent. </commentary></example>
+tools: Glob, Grep, Read, Write, Edit, MultiEdit, mcp__playwright-test__browser_console_messages, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_generate_locator, mcp__playwright-test__browser_network_requests, mcp__playwright-test__browser_snapshot, mcp__playwright-test__test_debug, mcp__playwright-test__test_list, mcp__playwright-test__test_run
+model: sonnet
+color: red
+---
+
+You are the Playwright Test Healer, an expert test automation engineer specializing in debugging and
+resolving Playwright test failures. Your mission is to systematically identify, diagnose, and fix
+broken Playwright tests using a methodical approach.
+
+Your workflow:
+1. **Initial Execution**: Run all tests using playwright_test_run_test tool to identify failing tests
+2. **Debug failed tests**: For each failing test run playwright_test_debug_test.
+3. **Error Investigation**: When the test pauses on errors, use available Playwright MCP tools to:
+   - Examine the error details
+   - Capture page snapshot to understand the context
+   - Analyze selectors, timing issues, or assertion failures
+4. **Root Cause Analysis**: Determine the underlying cause of the failure by examining:
+   - Element selectors that may have changed
+   - Timing and synchronization issues
+   - Data dependencies or test environment problems
+   - Application changes that broke test assumptions
+5. **Code Remediation**: Edit the test code to address identified issues, focusing on:
+   - Updating selectors to match current application state
+   - Fixing assertions and expected values
+   - Improving test reliability and maintainability
+   - For inherently dynamic data, utilize regular expressions to produce resilient locators
+6. **Verification**: Restart the test after each fix to validate the changes
+7. **Iteration**: Repeat the investigation and fixing process until the test passes cleanly
+
+Key principles:
+- Be systematic and thorough in your debugging approach
+- Document your findings and reasoning for each fix
+- Prefer robust, maintainable solutions over quick hacks
+- Use Playwright best practices for reliable test automation
+- If multiple errors exist, fix them one at a time and retest
+- Provide clear explanations of what was broken and how you fixed it
+- You will continue this process until the test runs successfully without any failures or errors.
+- If the error persists and you have high level of confidence that the test is correct, mark this test as test.fixme()
+  so that it is skipped during the execution. Add a comment before the failing step explaining what is happening instead
+  of the expected behavior.
+- Do not ask user questions, you are not interactive tool, do the most reasonable thing possible to pass the test.
+- Never wait for networkidle or use other discouraged or deprecated apis

--- a/.claude/agents/playwright-test-planner.md
+++ b/.claude/agents/playwright-test-planner.md
@@ -1,0 +1,93 @@
+---
+name: playwright-test-planner
+description: Use this agent when you need to create comprehensive test plan for a web application or website. Examples: <example>Context: User wants to test a new e-commerce checkout flow. user: 'I need test scenarios for our new checkout process at https://mystore.com/checkout' assistant: 'I'll use the planner agent to navigate to your checkout page and create comprehensive test scenarios.' <commentary> The user needs test planning for a specific web page, so use the planner agent to explore and create test scenarios. </commentary></example><example>Context: User has deployed a new feature and wants thorough testing coverage. user: 'Can you help me test our new user dashboard at https://app.example.com/dashboard?' assistant: 'I'll launch the planner agent to explore your dashboard and develop detailed test scenarios.' <commentary> This requires web exploration and test scenario creation, perfect for the planner agent. </commentary></example>
+tools: Glob, Grep, Read, Write, mcp__playwright-test__browser_click, mcp__playwright-test__browser_close, mcp__playwright-test__browser_console_messages, mcp__playwright-test__browser_drag, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_file_upload, mcp__playwright-test__browser_handle_dialog, mcp__playwright-test__browser_hover, mcp__playwright-test__browser_navigate, mcp__playwright-test__browser_navigate_back, mcp__playwright-test__browser_network_requests, mcp__playwright-test__browser_press_key, mcp__playwright-test__browser_select_option, mcp__playwright-test__browser_snapshot, mcp__playwright-test__browser_take_screenshot, mcp__playwright-test__browser_type, mcp__playwright-test__browser_wait_for, mcp__playwright-test__planner_setup_page
+model: sonnet
+color: green
+---
+
+You are an expert web test planner with extensive experience in quality assurance, user experience testing, and test
+scenario design. Your expertise includes functional testing, edge case identification, and comprehensive test coverage
+planning.
+
+You will:
+
+1. **Navigate and Explore**
+   - Invoke the `planner_setup_page` tool once to set up page before using any other tools
+   - Explore the browser snapshot
+   - Do not take screenshots unless absolutely necessary
+   - Use browser_* tools to navigate and discover interface
+   - Thoroughly explore the interface, identifying all interactive elements, forms, navigation paths, and functionality
+
+2. **Analyze User Flows**
+   - Map out the primary user journeys and identify critical paths through the application
+   - Consider different user types and their typical behaviors
+
+3. **Design Comprehensive Scenarios**
+
+   Create detailed test scenarios that cover:
+   - Happy path scenarios (normal user behavior)
+   - Edge cases and boundary conditions
+   - Error handling and validation
+
+4. **Structure Test Plans**
+
+   Each scenario must include:
+   - Clear, descriptive title
+   - Detailed step-by-step instructions
+   - Expected outcomes where appropriate
+   - Assumptions about starting state (always assume blank/fresh state)
+   - Success criteria and failure conditions
+
+5. **Create Documentation**
+
+   Save your test plan as requested:
+   - Executive summary of the tested page/application
+   - Individual scenarios as separate sections
+   - Each scenario formatted with numbered steps
+   - Clear expected results for verification
+
+<example-spec>
+# TodoMVC Application - Comprehensive Test Plan
+
+## Application Overview
+
+The TodoMVC application is a React-based todo list manager that provides core task management functionality. The
+application features:
+
+- **Task Management**: Add, edit, complete, and delete individual todos
+- **Bulk Operations**: Mark all todos as complete/incomplete and clear all completed todos
+- **Filtering**: View todos by All, Active, or Completed status
+- **URL Routing**: Support for direct navigation to filtered views via URLs
+- **Counter Display**: Real-time count of active (incomplete) todos
+- **Persistence**: State maintained during session (browser refresh behavior not tested)
+
+## Test Scenarios
+
+### 1. Adding New Todos
+
+**Seed:** `tests/seed.spec.ts`
+
+#### 1.1 Add Valid Todo
+**Steps:**
+1. Click in the "What needs to be done?" input field
+2. Type "Buy groceries"
+3. Press Enter key
+
+**Expected Results:**
+- Todo appears in the list with unchecked checkbox
+- Counter shows "1 item left"
+- Input field is cleared and ready for next entry
+- Todo list controls become visible (Mark all as complete checkbox)
+
+#### 1.2
+...
+</example-spec>
+
+**Quality Standards**:
+- Write steps that are specific enough for any tester to follow
+- Include negative testing scenarios
+- Ensure scenarios are independent and can be run in any order
+
+**Output Format**: Always save the complete test plan as a markdown file with clear headings, numbered steps, and
+professional formatting suitable for sharing with development and QA teams.

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -5,15 +5,19 @@
 name: CI - Build and Test
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on every pushed commit, on any branch
   push:
-    branches: ["main"]
 
   # Runs on pull requests
   pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+# Cancel a ref's in-progress run when a newer commit is pushed, to save CI minutes
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Build job

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -79,4 +79,6 @@ jobs:
           path: playwright-report/
           retention-days: 30
       - name: Build with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next build
+        # Use the project's build script (next build --webpack); a bare `next build`
+        # defaults to Turbopack in Next 16 and errors against the webpack config.
+        run: ${{ steps.detect-package-manager.outputs.runner }} build

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ yarn-error.log*
 .idea
 /dev/
 /playwright-report/
+/test-results/
+/.playwright-mcp/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,12 @@
 {
   "mcpServers": {
+    "playwright-test": {
+      "command": "npx",
+      "args": [
+        "playwright",
+        "run-test-mcp-server"
+      ]
+    },
     "webstorm": {
       "url": "http://127.0.0.1:64542/stream",
       "type": "http"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // Single worker: the app coordinates one DuckDB/OPFS session per origin, so
+  // concurrent browsers contend over the same OPFS files ("Access Handles cannot
+  // be created if there is another open") and flake. Tests must run serially.
+  workers: 1,
   reporter: 'html',
   use: {
     baseURL: 'http://localhost:3000',
@@ -22,5 +25,10 @@ export default defineConfig({
     command: 'pnpm dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
+    // Exposes the dev-only __relationsStore hook (see relations.state.ts) that the
+    // test helpers use to await state propagation. Note: if a plain `pnpm dev` is
+    // already running, Playwright reuses it and this env is NOT applied - stop it
+    // first so the e2e server starts with the flag.
+    env: { NEXT_PUBLIC_E2E: '1' },
   },
 });

--- a/src/platform/global-data.ts
+++ b/src/platform/global-data.ts
@@ -5,7 +5,7 @@ import type {StorageDestination} from "@/model/database-connection";
 export const DASH_STORAGE_VERSION = 1 // increment this if there are breaking changes to the storage format
 export const LOADING_TIMER_OFFSET_MS = 150; // how long the query needs to run before showing the loading spinner [ms]
 
-export const STORAGE_THROTTLE_TIME_MS = 2_000; // how long to wait before saving the state again [ms]
+export const STORAGE_THROTTLE_TIME_MS = 1_000; // how long to wait before saving the state again [ms]
 
 export const ENABLE_AUTOLOAD_IN_DEBUG = false
 export const DASH_DOMAIN = 'app.dash.builders'

--- a/src/state/relations.state.ts
+++ b/src/state/relations.state.ts
@@ -661,3 +661,11 @@ export const useRelationsState = createWithEqualityFn(
         }
     )
 );
+
+// E2E-only: expose the store so Playwright tests can await state propagation
+// (e.g. that an edited query has committed) instead of relying on timing. Gated
+// on NEXT_PUBLIC_E2E, which the Playwright webServer sets - so it is absent from
+// normal `pnpm dev` and from production builds (the block is dead-code stripped).
+if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_E2E === '1') {
+    (window as unknown as { __relationsStore?: typeof useRelationsState }).__relationsStore = useRelationsState;
+}

--- a/test/project-persistence.spec.ts
+++ b/test/project-persistence.spec.ts
@@ -1,0 +1,39 @@
+// seed: test/seed.spec.ts
+import { test, expect } from '@playwright/test';
+import {
+  openApp,
+  createProjectWithQuery,
+  selectResultView,
+  setChartColumn,
+  expectBarChartVisible,
+  expectSql,
+  expectPersistsAcrossReloadReopenAndUrl,
+} from './utils';
+
+test.describe('Project persistence', () => {
+  test('a bar chart persists across reload, navigation, and direct URL', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await openApp(page);
+    const ctx = await createProjectWithQuery(page, {
+      projectName: 'E2E Persist Test',
+      queryName: 'Range Query',
+      sql: 'SELECT * FROM range(10)',
+    });
+
+    // The query ran: 10 rows (range 0..9).
+    await expect(page.getByText('1 to 10 of 10')).toBeVisible();
+
+    // Turn it into a bar chart of the single "range" column.
+    await selectResultView(page, 'Chart');
+    await setChartColumn(page, 'X-Axis', 'range');
+    await setChartColumn(page, 'Y-Axis', 'range');
+    await expectBarChartVisible(page);
+
+    // The SQL and the bar chart survive reload, reopen, and direct URL.
+    await expectPersistsAcrossReloadReopenAndUrl(page, ctx, async (p) => {
+      await expectSql(p, 'SELECT * FROM range(10)');
+      await expectBarChartVisible(p);
+    });
+  });
+});

--- a/test/seed.spec.ts
+++ b/test/seed.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Seed test for the Playwright Test Agents (planner / generator / healer).
+ *
+ * This test runs FIRST and is the template every generated test is cloned from,
+ * so its only job is to land the app in a clean, deterministic, ready-to-drive
+ * state. Generated tests inherit this setup and append their own steps after the
+ * "app ready" checkpoint below.
+ *
+ * Three things every run needs:
+ *   1. Auto-connect to DuckDB WASM via the `?api=wasm` URL param. On localhost a
+ *      fresh profile has no saved connection and does NOT auto-connect (autoload
+ *      is only enabled on the production domain), so init otherwise parks at
+ *      "Selecting connection" and force-opens the connection dialog. `?api=wasm`
+ *      is the app's own deep-link to establish a working connection headlessly
+ *      (see config-utils.ts / init.state.ts).
+ *   2. Suppress the first-run welcome tour — a modal that otherwise opens on a
+ *      fresh profile and blocks every interaction — by pre-seeding its
+ *      localStorage flag before any app code runs.
+ *   3. Wait for DuckDB WASM initialization to finish. Until it does, AppGate
+ *      shows a "Loading..." screen instead of the app shell.
+ */
+test.describe('Test group', () => {
+  test('seed', async ({ page }) => {
+    // 1. Skip the onboarding tour before the app boots (see onboarding.state.ts).
+    await page.addInitScript(() => {
+      window.localStorage.setItem('dash-onboarding-seen', 'true');
+    });
+
+    // 2. Load the app and auto-connect to DuckDB WASM. baseURL
+    //    (http://localhost:3000) comes from playwright.config.ts.
+    await page.goto('/?api=wasm');
+
+    // 3. App ready: init reaches 'complete', the AppGate "Loading..." gate is
+    //    replaced by the app shell, and the top-bar Settings button mounts.
+    //    WASM init can take a few seconds, so allow extra time.
+    await expect(page.getByRole('button', { name: 'Settings' })).toBeVisible({ timeout: 30_000 });
+
+    // generate code here.
+  });
+});

--- a/test/table-sort-persistence.spec.ts
+++ b/test/table-sort-persistence.spec.ts
@@ -1,0 +1,32 @@
+// seed: test/seed.spec.ts
+import { test } from '@playwright/test';
+import {
+  openApp,
+  createProjectWithQuery,
+  sortColumn,
+  expectFirstDataRow,
+  expectPersistsAcrossReloadReopenAndUrl,
+} from './utils';
+
+test.describe('Table sort persistence', () => {
+  test('a table sort order persists across reload, navigation, and direct URL', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await openApp(page);
+    const ctx = await createProjectWithQuery(page, {
+      projectName: 'E2E Sort Test',
+      queryName: 'Range Query',
+      sql: 'SELECT * FROM range(10)',
+    });
+
+    // range(10) is naturally ascending (first row is 0). Sort descending so the
+    // first row becomes 9 - a visible, assertable change.
+    await sortColumn(page, 'range', 'DESC');
+    await expectFirstDataRow(page, '9');
+
+    // The descending sort survives reload, reopen, and direct URL.
+    await expectPersistsAcrossReloadReopenAndUrl(page, ctx, async (p) => {
+      await expectFirstDataRow(p, '9');
+    });
+  });
+});

--- a/test/utils/app.ts
+++ b/test/utils/app.ts
@@ -1,0 +1,28 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * App-shell helpers: getting the Dash app into a ready, connected state.
+ *
+ * On localhost a fresh profile does not auto-connect to DuckDB and shows a
+ * connection dialog, and a first-run welcome tour modal blocks interaction.
+ * These helpers side-step both the same way the seed test does.
+ */
+
+/** Wait until the app shell is ready: DuckDB connected and init complete. */
+export async function expectAppReady(page: Page): Promise<void> {
+  // The top-bar Settings button only mounts once init reaches 'complete'.
+  await expect(page.getByRole('button', { name: 'Settings', exact: true })).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Load the app connected to DuckDB WASM, with the welcome tour suppressed.
+ * `?api=wasm` auto-establishes the connection (and saves it to history, so later
+ * plain reloads reconnect without the param). Call once at the start of a test.
+ */
+export async function openApp(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('dash-onboarding-seen', 'true');
+  });
+  await page.goto('/?api=wasm');
+  await expectAppReady(page);
+}

--- a/test/utils/app.ts
+++ b/test/utils/app.ts
@@ -11,7 +11,8 @@ import { expect, type Page } from '@playwright/test';
 /** Wait until the app shell is ready: DuckDB connected and init complete. */
 export async function expectAppReady(page: Page): Promise<void> {
   // The top-bar Settings button only mounts once init reaches 'complete'.
-  await expect(page.getByRole('button', { name: 'Settings', exact: true })).toBeVisible({ timeout: 30_000 });
+  // Cold DuckDB WASM init is slower on CI, so allow generous time.
+  await expect(page.getByRole('button', { name: 'Settings', exact: true })).toBeVisible({ timeout: 45_000 });
 }
 
 /**

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Composable building blocks for Dash e2e tests. Import from here:
+ *   import { openApp, createProjectWithQuery, expectPersistsAcrossReloadReopenAndUrl } from './utils';
+ */
+export * from './app';
+export * from './query';
+export * from './project';
+export * from './views';
+export * from './persistence';

--- a/test/utils/persistence.ts
+++ b/test/utils/persistence.ts
@@ -1,0 +1,51 @@
+import { type Page } from '@playwright/test';
+import { STORAGE_THROTTLE_TIME_MS } from '@/platform/global-data';
+import { expectAppReady } from './app';
+import { goToProjectsList, openProject, openQuery, type QueryContext } from './project';
+
+/**
+ * Persistence harness: verify some piece of query state survives every way a
+ * query can be re-entered.
+ */
+
+/**
+ * Wait for the relation state to be flushed to the project's DuckDB storage.
+ * Saves are autosaved on a trailing throttle (STORAGE_THROTTLE_TIME_MS); waiting
+ * 2x guarantees the latest edits are on disk before a reload / reopen restores
+ * from storage.
+ */
+export async function waitForPersist(page: Page): Promise<void> {
+  await page.waitForTimeout(2 * STORAGE_THROTTLE_TIME_MS);
+}
+
+/**
+ * Assert that `assert` still holds after each of the three ways a query is
+ * re-entered:
+ *   A. a full page reload,
+ *   B. navigating back to the projects list and reopening the project + query,
+ *   C. opening the query by its direct URL.
+ * Flushes pending saves first so the reload restores the latest state.
+ */
+export async function expectPersistsAcrossReloadReopenAndUrl(
+  page: Page,
+  ctx: QueryContext,
+  assert: (page: Page) => Promise<void>,
+): Promise<void> {
+  await waitForPersist(page);
+
+  // A - reload
+  await page.reload();
+  await expectAppReady(page);
+  await assert(page);
+
+  // B - back to the projects list, then reopen the project and the query
+  await goToProjectsList(page);
+  await openProject(page, ctx.projectName);
+  await openQuery(page, ctx.queryName);
+  await assert(page);
+
+  // C - open the query directly by its URL
+  await page.goto(ctx.queryUrl);
+  await expectAppReady(page);
+  await assert(page);
+}

--- a/test/utils/project.ts
+++ b/test/utils/project.ts
@@ -1,0 +1,79 @@
+import { expect, type Page } from '@playwright/test';
+import { runQuery, setSql } from './query';
+
+/**
+ * Project + workspace navigation helpers, and a one-call "starter" that gives a
+ * test a project with a runnable query so view-specific tests don't rebuild it.
+ */
+
+export interface QueryContext {
+  projectName: string;
+  queryName: string;
+  sql: string;
+  /** Direct URL of the created query, for the open-by-URL persistence path. */
+  queryUrl: string;
+}
+
+/** Create a project from the projects list and land inside its workspace. */
+export async function createProject(page: Page, name: string): Promise<void> {
+  await page.getByRole('button', { name: 'New project' }).first().click();
+  const dialog = page.getByRole('dialog', { name: 'New project' });
+  await dialog.getByRole('textbox', { name: 'Name' }).fill(name);
+  await dialog.getByRole('button', { name: 'Create' }).click();
+  await expect(page).toHaveURL(/\/projects\/[^/]+\/workspace$/);
+  await expect(page.getByRole('button', { name: `Open ${name}` })).toBeVisible();
+}
+
+/**
+ * Create a query from the fresh-project welcome screen and open it. Returns the
+ * query's direct URL.
+ */
+export async function createQuery(page: Page, name: string): Promise<string> {
+  await page.getByText('New Query', { exact: true }).click();
+  const dialog = page.getByRole('dialog', { name: 'New Query' });
+  await dialog.getByRole('textbox', { name: 'Enter a name' }).fill(name);
+  await dialog.getByRole('button', { name: 'Create' }).click();
+  await expect(page).toHaveURL(/\/projects\/[^/]+\/workspace\/[^/]+$/);
+  return page.url();
+}
+
+/** Go back to the projects list. */
+export async function goToProjectsList(page: Page): Promise<void> {
+  // The sidebar "All projects" entry is an <a> without href (client-side nav),
+  // so it is not exposed as a link role; match it by text.
+  await page.getByText('All projects', { exact: true }).click();
+  await expect(page).toHaveURL(/\/projects$/);
+}
+
+/** Open a project by name from the projects list. */
+export async function openProject(page: Page, name: string): Promise<void> {
+  await page.getByRole('button', { name }).click();
+  await expect(page).toHaveURL(/\/projects\/[^/]+\/workspace$/);
+}
+
+/** Open a query by name from the project workspace overview. */
+export async function openQuery(page: Page, name: string): Promise<void> {
+  await page.getByRole('link', { name }).click();
+  await expect(page).toHaveURL(/\/workspace\/[^/]+$/);
+}
+
+/**
+ * Starter: create a project, add a query, set its SQL and run it. Assumes the
+ * app is already open on the projects list (see `openApp`). Returns the context
+ * needed to drive persistence checks.
+ */
+export async function createProjectWithQuery(
+  page: Page,
+  opts: { projectName?: string; queryName?: string; sql?: string } = {},
+): Promise<QueryContext> {
+  const projectName = opts.projectName ?? 'E2E Test Project';
+  const queryName = opts.queryName ?? 'Test Query';
+  const sql = opts.sql ?? 'SELECT * FROM range(10)';
+
+  await createProject(page, projectName);
+  const queryUrl = await createQuery(page, queryName);
+  await setSql(page, sql);
+  await runQuery(page);
+
+  return { projectName, queryName, sql, queryUrl };
+}

--- a/test/utils/query.ts
+++ b/test/utils/query.ts
@@ -12,34 +12,46 @@ import { expect, type Page } from '@playwright/test';
  * clobbers the query. Relies on the dev-only `__relationsStore` hook exposed in
  * `src/state/relations.state.ts`.
  */
-export async function waitForBaseQueryCommitted(page: Page, sql: string): Promise<void> {
+export async function waitForBaseQueryCommitted(page: Page, sql: string, timeout = 10_000): Promise<void> {
   await page.waitForFunction((expected) => {
     const store = (window as unknown as { __relationsStore?: any }).__relationsStore;
     if (!store) return false;
     const relations = Object.values(store.getState().relations ?? {});
     return relations.some((r: any) => r?.query?.baseQuery === expected);
-  }, sql);
+  }, sql, { timeout });
 }
 
 /**
- * Replace the SQL editor contents and wait for the change to commit. Monaco's
- * textarea is not fillable and its select-all is unreliable under automation, so
- * we set the model value directly (which fires Monaco's change event, exactly as
- * typing would), then wait for the debounced commit to reach the store.
+ * Replace the SQL editor contents and wait for the change to commit to the
+ * store. Monaco's textarea is not fillable and its select-all is unreliable
+ * under automation, so we set the model value directly (which fires Monaco's
+ * change event, exactly as typing would).
+ *
+ * The edit is applied inside a retry loop: `@monaco-editor/react` wires its
+ * onChange subscription in an effect just after the editor mounts, so on a slow
+ * (CI) machine a one-shot setValue can land in that gap and be dropped, leaving
+ * the query uncommitted. We first wait for the editor *instance* to exist (proof
+ * onMount ran), then re-apply until the commit actually reaches the store - each
+ * attempt clears the model first so a freshly-attached subscription sees a real
+ * change even when the target text is unchanged.
  */
 export async function setSql(page: Page, sql: string): Promise<void> {
-  await page.locator('.monaco-editor').first().waitFor({ state: 'visible' });
   await page.waitForFunction(() => {
     const m = (window as unknown as { monaco?: any }).monaco;
-    return !!m?.editor?.getModels?.().length;
+    return !!m?.editor?.getEditors?.().some((e: any) => e.getModel()?.uri.toString().includes('sql-editor'));
   });
-  await page.evaluate((value) => {
-    const monaco = (window as unknown as { monaco: any }).monaco;
-    const models = monaco.editor.getModels();
-    const model = models.find((m: any) => m.uri.toString().includes('sql-editor')) ?? models[0];
-    model.setValue(value);
-  }, sql);
-  await waitForBaseQueryCommitted(page, sql);
+  await expect(async () => {
+    await page.evaluate((value) => {
+      const monaco = (window as unknown as { monaco: any }).monaco;
+      const editor = monaco.editor
+        .getEditors()
+        .find((e: any) => e.getModel()?.uri.toString().includes('sql-editor'));
+      const model = editor.getModel();
+      if (model.getValue() === value) model.setValue('');
+      model.setValue(value);
+    }, sql);
+    await waitForBaseQueryCommitted(page, sql, 2_000);
+  }).toPass({ timeout: 20_000 });
 }
 
 /**

--- a/test/utils/query.ts
+++ b/test/utils/query.ts
@@ -1,0 +1,63 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Query-editor helpers: driving the Monaco SQL editor and its execution.
+ */
+
+/**
+ * Wait until an edit has committed to the relation store, i.e. some relation's
+ * `query.baseQuery` equals `sql`. The editor commits on a debounce, and every
+ * relation edit replaces the whole relation from a React snapshot - so we must
+ * let the commit land before the next edit, or it clones a stale snapshot and
+ * clobbers the query. Relies on the dev-only `__relationsStore` hook exposed in
+ * `src/state/relations.state.ts`.
+ */
+export async function waitForBaseQueryCommitted(page: Page, sql: string): Promise<void> {
+  await page.waitForFunction((expected) => {
+    const store = (window as unknown as { __relationsStore?: any }).__relationsStore;
+    if (!store) return false;
+    const relations = Object.values(store.getState().relations ?? {});
+    return relations.some((r: any) => r?.query?.baseQuery === expected);
+  }, sql);
+}
+
+/**
+ * Replace the SQL editor contents and wait for the change to commit. Monaco's
+ * textarea is not fillable and its select-all is unreliable under automation, so
+ * we set the model value directly (which fires Monaco's change event, exactly as
+ * typing would), then wait for the debounced commit to reach the store.
+ */
+export async function setSql(page: Page, sql: string): Promise<void> {
+  await page.locator('.monaco-editor').first().waitFor({ state: 'visible' });
+  await page.waitForFunction(() => {
+    const m = (window as unknown as { monaco?: any }).monaco;
+    return !!m?.editor?.getModels?.().length;
+  });
+  await page.evaluate((value) => {
+    const monaco = (window as unknown as { monaco: any }).monaco;
+    const models = monaco.editor.getModels();
+    const model = models.find((m: any) => m.uri.toString().includes('sql-editor')) ?? models[0];
+    model.setValue(value);
+  }, sql);
+  await waitForBaseQueryCommitted(page, sql);
+}
+
+/**
+ * Run the query via the editor's own "run-code" action, which uses the live
+ * editor value (the on-screen "Run Query" button runs the relation's committed
+ * query, which lags the editor by a debounce).
+ */
+export async function runQuery(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const monaco = (window as unknown as { monaco: any }).monaco;
+    const editor = monaco.editor
+      .getEditors()
+      .find((e: any) => e.getModel()?.uri.toString().includes('sql-editor'));
+    editor.getAction('run-code').run();
+  });
+}
+
+/** Assert the SQL editor shows the given query text. */
+export async function expectSql(page: Page, sql: string): Promise<void> {
+  await expect(page.locator('.monaco-editor[data-uri*="sql-editor"]')).toContainText(sql);
+}

--- a/test/utils/views/chart.ts
+++ b/test/utils/views/chart.ts
@@ -1,0 +1,22 @@
+import { expect, type Page } from '@playwright/test';
+
+/** Chart-view helpers. Switch to it first with `selectResultView(page, 'Chart')`. */
+
+export type ChartAxis = 'X-Axis' | 'Y-Axis' | 'Group';
+
+/**
+ * Assign a column to a chart axis. Each axis dropdown keeps its selected item
+ * mounted after closing, so an earlier matching option can linger in the DOM;
+ * the just-opened popover is appended last, so target the last match.
+ */
+export async function setChartColumn(page: Page, axis: ChartAxis, column: string): Promise<void> {
+  await page.getByRole('combobox').filter({ hasText: axis }).click();
+  await page.getByRole('option', { name: column }).last().click();
+}
+
+/** Assert a bar chart is rendered (type "Bar" + an ECharts instance on screen). */
+export async function expectBarChartVisible(page: Page): Promise<void> {
+  await expect(page.getByRole('combobox').filter({ hasText: 'Bar' })).toBeVisible();
+  // ECharts tags its root node with this attribute once it has rendered.
+  await expect(page.locator('[_echarts_instance_]')).toBeVisible();
+}

--- a/test/utils/views/common.ts
+++ b/test/utils/views/common.ts
@@ -1,0 +1,10 @@
+import { type Page } from '@playwright/test';
+
+/** Shared across all result views: switching the "Display as" view. */
+
+export type ResultView = 'Table' | 'Chart' | 'Text' | 'Select' | 'Slider';
+
+/** Switch the result view (the "Display as" toolbar). */
+export async function selectResultView(page: Page, view: ResultView): Promise<void> {
+  await page.getByRole('button', { name: view, exact: true }).click();
+}

--- a/test/utils/views/index.ts
+++ b/test/utils/views/index.ts
@@ -1,0 +1,4 @@
+/** Result-view helpers, split by view type. */
+export * from './common';
+export * from './chart';
+export * from './table';

--- a/test/utils/views/table.ts
+++ b/test/utils/views/table.ts
@@ -1,0 +1,25 @@
+import { expect, type Page } from '@playwright/test';
+
+/** Table-view helpers. */
+
+/**
+ * Sort a table column. Clicking a column header cycles none -> ASC -> DESC, so
+ * we click once for ASC and twice for DESC (from an unsorted column).
+ */
+export async function sortColumn(page: Page, column: string, direction: 'ASC' | 'DESC'): Promise<void> {
+  const header = page.getByRole('columnheader', { name: column }).getByRole('button', { name: column });
+  await header.click();
+  if (direction === 'DESC') {
+    await header.click();
+  }
+}
+
+/** The first data row of the table (skips the header row group). */
+export function firstDataRow(page: Page) {
+  return page.getByRole('rowgroup').last().getByRole('row').first();
+}
+
+/** Assert the first data row of the table contains the given text. */
+export async function expectFirstDataRow(page: Page, text: string): Promise<void> {
+  await expect(firstDataRow(page)).toContainText(text);
+}


### PR DESCRIPTION
- Composable helpers in test/utils (app, query, project, views/, persistence)
- seed connects via ?api=wasm and suppresses the onboarding tour
- project-persistence: bar chart survives reload / reopen / direct-URL
- table-sort-persistence: table sort order survives the same
- dev-only __relationsStore hook gated on NEXT_PUBLIC_E2E so setSql awaits commit
- playwright.config: workers=1 (single OPFS session), webServer sets NEXT_PUBLIC_E2E
- CI (nextjs.yml) runs e2e on every push, with a concurrency guard
- adds playwright-test MCP server + planner/generator/healer agent defs